### PR TITLE
bpの加算処理を累積加算できるように機能追加

### DIFF
--- a/backend/db/models/__init__.py
+++ b/backend/db/models/__init__.py
@@ -15,4 +15,4 @@ from backend.db.models.tables.discount_tickets import DiscountTicket
 from backend.db.models.tables.bp_entries import BpEntry
 from backend.db.models.tables.user_week_preference import UserWeekPreference
 from backend.db.models.tables.mvp_awards import MVPAward
-
+from backend.db.models.tables.bp_ingest_cursors import BpIngestCursor

--- a/backend/db/models/common.py
+++ b/backend/db/models/common.py
@@ -14,7 +14,9 @@ from sqlalchemy import (
     UniqueConstraint,
     TIMESTAMP,
     JSON,
-    Index
+    Index,
+    BigInteger,
+    Float,
 )
 
 from sqlalchemy.dialects.postgresql import JSONB
@@ -46,5 +48,7 @@ __all__ = [
     "relationship",
     "func",
     "Base",
-    "Index"
+    "Index",
+    "BigInteger",
+    "Float",
 ]

--- a/backend/db/models/tables/bp_ingest_cursors.py
+++ b/backend/db/models/tables/bp_ingest_cursors.py
@@ -8,7 +8,6 @@ class BpIngestCursor(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
     user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
     date = Column(Date, nullable=False)  # アプリTZでの“その日”
-    device_id = Column(String(64), nullable=True)
 
     # 最後に処理した“単位数”（歩・距離で割った整数）を保持
     last_walk_units = Column(Integer, default=0, nullable=False)
@@ -21,6 +20,6 @@ class BpIngestCursor(Base):
     updated_at = Column(TIMESTAMP, server_default=func.now(), onupdate=func.now())
 
     __table_args__ = (
-        UniqueConstraint("user_id", "date", "device_id", name="uq_bp_cursor_user_date_device"),
+        UniqueConstraint("user_id", "date", name="uq_bp_cursor_user_date"),
         Index("idx_bp_cursor_user_date", "user_id", "date"),
     )

--- a/backend/db/models/tables/bp_ingest_cursors.py
+++ b/backend/db/models/tables/bp_ingest_cursors.py
@@ -1,0 +1,26 @@
+from backend.db.models.common import *
+
+# HealthKitの『当日累積』を安全に差分化するためのカーソル。
+# 同一ユーザー×日付×デバイスで、最後に処理した“単位数”を保持する。
+class BpIngestCursor(Base):
+    __tablename__ = "bp_ingest_cursors"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    date = Column(Date, nullable=False)  # アプリTZでの“その日”
+    device_id = Column(String(64), nullable=True)
+
+    # 最後に処理した“単位数”（歩・距離で割った整数）を保持
+    last_walk_units = Column(Integer, default=0, nullable=False)
+    last_run_units = Column(Integer, default=0, nullable=False)
+
+    # 最後に見た累積原値も保持（デバッグ/監査用）
+    last_steps_total = Column(BigInteger, default=0, nullable=False)
+    last_distance_total_km = Column(Float, default=0.0, nullable=False)
+
+    updated_at = Column(TIMESTAMP, server_default=func.now(), onupdate=func.now())
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "date", "device_id", name="uq_bp_cursor_user_date_device"),
+        Index("idx_bp_cursor_user_date", "user_id", "date"),
+    )

--- a/backend/db/models/tables/sp_records.py
+++ b/backend/db/models/tables/sp_records.py
@@ -14,3 +14,8 @@ class SPRecord(Base):
     created_at = Column(DateTime, server_default=func.now())
 
     user = relationship("User", back_populates="sp_records")
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "week_id", "date", "mode", name="uq_sp_user_week_date_mode"),
+        Index("idx_sp_user_week_date", "user_id", "week_id", "date"),
+    )

--- a/backend/features/points/bp_cursor_crud.py
+++ b/backend/features/points/bp_cursor_crud.py
@@ -1,0 +1,45 @@
+from sqlalchemy.orm import Session
+from datetime import date as DateType
+from backend.db.models.tables.bp_ingest_cursors import BpIngestCursor
+
+def get_cursor(db: Session, user_id: int, on_date: DateType, device_id: str | None) -> BpIngestCursor | None:
+    return (
+        db.query(BpIngestCursor)
+        .filter(
+            BpIngestCursor.user_id == user_id,
+            BpIngestCursor.date == on_date,
+            BpIngestCursor.device_id.is_(device_id) if device_id is None else BpIngestCursor.device_id == device_id
+        )
+        .first()
+    )
+
+def upsert_cursor(
+    db: Session,
+    user_id: int,
+    on_date: DateType,
+    device_id: str | None,
+    last_walk_units: int,
+    last_run_units: int,
+    last_steps_total: int,
+    last_distance_total_km: float,
+) -> BpIngestCursor:
+    cur = get_cursor(db, user_id, on_date, device_id)
+    if cur:
+        cur.last_walk_units = last_walk_units
+        cur.last_run_units = last_run_units
+        cur.last_steps_total = last_steps_total
+        cur.last_distance_total_km = last_distance_total_km
+    else:
+        cur = BpIngestCursor(
+            user_id=user_id,
+            date=on_date,
+            device_id=device_id,
+            last_walk_units=last_walk_units,
+            last_run_units=last_run_units,
+            last_steps_total=last_steps_total,
+            last_distance_total_km=last_distance_total_km,
+        )
+        db.add(cur)
+    db.commit()
+    db.refresh(cur)
+    return cur

--- a/backend/features/points/bp_cursor_crud.py
+++ b/backend/features/points/bp_cursor_crud.py
@@ -2,13 +2,12 @@ from sqlalchemy.orm import Session
 from datetime import date as DateType
 from backend.db.models.tables.bp_ingest_cursors import BpIngestCursor
 
-def get_cursor(db: Session, user_id: int, on_date: DateType, device_id: str | None) -> BpIngestCursor | None:
+def get_cursor(db: Session, user_id: int, on_date: DateType) -> BpIngestCursor | None:
     return (
         db.query(BpIngestCursor)
         .filter(
             BpIngestCursor.user_id == user_id,
             BpIngestCursor.date == on_date,
-            BpIngestCursor.device_id.is_(device_id) if device_id is None else BpIngestCursor.device_id == device_id
         )
         .first()
     )
@@ -17,13 +16,12 @@ def upsert_cursor(
     db: Session,
     user_id: int,
     on_date: DateType,
-    device_id: str | None,
     last_walk_units: int,
     last_run_units: int,
     last_steps_total: int,
     last_distance_total_km: float,
 ) -> BpIngestCursor:
-    cur = get_cursor(db, user_id, on_date, device_id)
+    cur = get_cursor(db, user_id, on_date)
     if cur:
         cur.last_walk_units = last_walk_units
         cur.last_run_units = last_run_units
@@ -33,7 +31,6 @@ def upsert_cursor(
         cur = BpIngestCursor(
             user_id=user_id,
             date=on_date,
-            device_id=device_id,
             last_walk_units=last_walk_units,
             last_run_units=last_run_units,
             last_steps_total=last_steps_total,

--- a/backend/features/points/bp_router.py
+++ b/backend/features/points/bp_router.py
@@ -26,7 +26,7 @@ def get_current_bp(
     return BPBalanceResponse(user_id=user_id, current_bp=current)
 
 # 歩数・距離によるBP加算（歩数/距離のみを使う）
-@router.post("/add", response_model=BPBalanceResponse, responses={
+@router.post("/add", response_model=BPChangeResponse, responses={
     200: {"description": "BP加算成功"},
     400: {"description": "リクエストが不正です"},
     401: {"description": "認証されていません"},
@@ -47,14 +47,48 @@ def add_bp(
             detail="歩数または距離のいずれかを指定してください",
         )
 
-    # サービスは“加算後の残高”を返す想定に統一
-    current_after = add_bp_from_activity(
+    # 差分算出：呼び出し前後の残高差分を delta として返す
+    before = fetch_current_bp(request.user_id, db)
+    after = add_bp_from_activity(
         user_id=request.user_id,
         steps=request.steps or 0,
         distance_km=request.distance_km or 0.0,
         db=db,
     )
-    return BPBalanceResponse(user_id=request.user_id, current_bp=current_after)
+    delta = after - before
+    return BPChangeResponse(user_id=request.user_id, delta_bp=delta, current_bp=after)
+
+# 累積（HealthKit）インジェスト
+@router.post("/ingest", response_model=BPChangeResponse, responses={
+    200: {"description": "累積データを反映しBPを加算（差分）しました"},
+    400: {"description": "リクエストが不正です"},
+    401: {"description": "認証されていません"},
+    403: {"description": "不正なBP操作です"},
+    500: {"description": "サーバーエラー"}
+})
+def ingest_bp_cumulative(
+    request: BPIngestRequest,
+    current_user = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    validate_user(request.user_id, current_user.id)
+
+    if (request.steps_total or 0) < 0 or (request.distance_total_km or 0.0) < 0.0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="累積の歩数/距離は0以上で指定してください",
+        )
+
+    before = fetch_current_bp(request.user_id, db)
+    after = add_bp_from_cumulative(
+        db=db,
+        user_id=request.user_id,
+        steps_total=request.steps_total or 0,
+        distance_total_km=request.distance_total_km or 0.0,
+        sent_date=request.sent_date,
+    )
+    delta = after - before
+    return BPChangeResponse(user_id=request.user_id, delta_bp=delta, current_bp=after)
 
 # BP減少（賭けや交換など）
 @router.post("/decrease", response_model=BPBalanceResponse, responses={

--- a/backend/features/points/bp_schemas.py
+++ b/backend/features/points/bp_schemas.py
@@ -2,6 +2,7 @@ from pydantic import BaseModel, Field
 from enum import Enum
 from typing import Literal
 from pydantic import ConfigDict
+from datetime import date
 
 # BP減少の理由を定義
 class BPDecreaseReason(str, Enum):
@@ -53,3 +54,13 @@ class BPBonusRequest(BaseModel):
     reason: BPBonusReason = Field(..., description="報酬の種類")
     detail: str | None = Field(None, description="補足情報（例：起床時間やイベント名など）")
 
+class BPIngestRequest(BaseModel):
+    # HealthKitなどの「当日累積」を送るためのエンドポイント用。
+    # サーバ側がカーソルで差分化して加点。
+    user_id: int = Field(..., description="ユーザーID")
+    steps_total: int = Field(0, ge=0, description="当日累積の歩数（0以上）")
+    distance_total_km: float = Field(0.0, ge=0, description="当日累積の距離（km, 0以上）")
+    device_id: str | None = Field(None, description="送信端末識別子（任意。複数端末時に差分混在を防ぐ）")
+    sent_date: date | None = Field(None, description="アプリTZでの当日日付。未指定ならサーバで“今日”を採用")
+
+    model_config = ConfigDict(extra="ignore")

--- a/backend/features/points/bp_schemas.py
+++ b/backend/features/points/bp_schemas.py
@@ -32,6 +32,12 @@ class BPBalanceResponse(BaseModel):
     user_id: int
     current_bp: int
 
+# BP増減量と最新残高を返すレスポンス
+class BPChangeResponse(BaseModel):
+    user_id: int
+    delta_bp: int = Field(..., description="今回増減したBP")
+    current_bp: int = Field(..., description="変更後のBP残高")
+
 # ランキング報酬によるBP増加リクエスト
 class BPRewardFromRankingRequest(BaseModel):
     user_id: int = Field(..., description="ユーザーID")
@@ -54,13 +60,11 @@ class BPBonusRequest(BaseModel):
     reason: BPBonusReason = Field(..., description="報酬の種類")
     detail: str | None = Field(None, description="補足情報（例：起床時間やイベント名など）")
 
+# HealthKitなどの「当日累積」を送るためのエンドポイント用。
+# サーバ側がカーソルで差分化して加点。
 class BPIngestRequest(BaseModel):
-    # HealthKitなどの「当日累積」を送るためのエンドポイント用。
-    # サーバ側がカーソルで差分化して加点。
     user_id: int = Field(..., description="ユーザーID")
-    steps_total: int = Field(0, ge=0, description="当日累積の歩数（0以上）")
-    distance_total_km: float = Field(0.0, ge=0, description="当日累積の距離（km, 0以上）")
-    device_id: str | None = Field(None, description="送信端末識別子（任意。複数端末時に差分混在を防ぐ）")
-    sent_date: date | None = Field(None, description="アプリTZでの当日日付。未指定ならサーバで“今日”を採用")
-
+    steps_total: int = Field(0, description="当日累積の歩数（0以上）")
+    distance_total_km: float = Field(0.0, description="当日累積の距離（km, 0以上）")
+    sent_date: date | None = Field(None, description="アプリTZでの当日日付。未指定ならサーバで“今日”")
     model_config = ConfigDict(extra="ignore")

--- a/backend/features/points/point_service.py
+++ b/backend/features/points/point_service.py
@@ -11,9 +11,61 @@ from backend.features.points.sp_crud import (
 from backend.features.points.bp_crud import (
     get_current_bp, increase_bp, get_bet_entry, set_result_bp, add_ranking_reward_bp
 )
+from backend.features.points.bp_cursor_crud import get_cursor, upsert_cursor
+from backend.features.weeks.week_service import today_local
+
 
 # 現在のBP取得
 def fetch_current_bp(user_id: int, db: Session) -> int:
+    return get_current_bp(user_id, db)
+
+def add_bp_from_cumulative(
+    db: Session,
+    user_id: int,
+    steps_total: int,
+    distance_total_km: float,
+    device_id: str | None = None,
+    sent_date: date | None = None,
+) -> int:
+    """
+    累積（当日トータル）から“単位差分のみ”を加算。
+    - 端末リトライや順不同にも耐性あり
+    - 当日が変わればカーソルは日付キーで自然リセット
+    """
+    # アプリのTZでの“今日”
+    on_date = sent_date or today_local()
+
+    # 現在の累積から “単位数” を計算
+    new_walk_units = steps_total // BP_WALK_UNIT
+    new_run_units = int(distance_total_km // BP_RUN_UNIT)
+
+    cur = get_cursor(db, user_id, on_date, device_id)
+    if cur is None:
+        # 初回：累積ぶんを丸ごと“単位換算”で付与
+        delta_walk_units = new_walk_units
+        delta_run_units  = new_run_units
+    else:
+        # 通常：単位差分のみ
+        delta_walk_units = max(new_walk_units - cur.last_walk_units, 0)
+        delta_run_units  = max(new_run_units  - cur.last_run_units, 0)
+
+    bp_gain = delta_walk_units * BP_WALK_GAIN + delta_run_units * BP_RUN_GAIN
+    if bp_gain > 0:
+        increase_bp(user_id, bp_gain, reason="activity", db=db)
+
+    # カーソル更新
+    upsert_cursor(
+        db=db,
+        user_id=user_id,
+        on_date=on_date,
+        device_id=device_id,
+        last_walk_units=new_walk_units,
+        last_run_units=new_run_units,
+        last_steps_total=steps_total,
+        last_distance_total_km=distance_total_km,
+    )
+
+    # 最新残高を返却
     return get_current_bp(user_id, db)
 
 # 歩数に応じたBP加算
@@ -103,23 +155,33 @@ def get_unit_info(
     redemption: bool,
     step_count: int,
     distance_km: float
-) -> tuple[int, int, int, str, dict]:
-    config_map = {
-        ("walking", False): (SP_WALK_UNIT, SP_WALK_GAIN, step_count, "walk"),
-        ("walking", True):  (SP_WALK_RDM_UNIT, SP_WALK_RDM_GAIN, step_count, "walk"),
-        ("running", False): (SP_RUN_UNIT, SP_RUN_GAIN, distance_km, "distance"),
-        ("running", True):  (SP_RUN_RDM_UNIT, SP_RUN_RDM_GAIN, distance_km, "distance")
-    }
-
-    config = config_map.get((mode, redemption))
-    if not config:
+) -> tuple[str, int, int, int, str, dict]:
+    if mode == "walking":
+        record_mode = "walking_rdm" if redemption else "walking"
+        unit  = SP_WALK_RDM_UNIT if redemption else SP_WALK_UNIT
+        gain  = SP_WALK_RDM_GAIN if redemption else SP_WALK_GAIN
+        value = step_count
+        key   = "walk"
+    elif mode == "running":
+        record_mode = "running_rdm" if redemption else "running"
+        unit  = SP_RUN_RDM_UNIT if redemption else SP_RUN_UNIT
+        gain  = SP_RUN_RDM_GAIN if redemption else SP_RUN_GAIN
+        value = distance_km
+        key   = "distance"
+    else:
         raise ValueError(f"未対応のアクティビティモードです: mode={mode}, redemption={redemption}")
 
-    unit, gain, value, key = config
     current_units = int(value // unit)
-    detail = {"mode": mode, key: value, "redemption": redemption, "source": key}
-
-    return current_units, gain, unit, key, detail
+    detail = {
+        "mode": mode,               # 入力モード
+        "record_mode": record_mode, # 保存モード（*_rdm を区別）
+        key: value,
+        "unit": unit,
+        "gain": gain,
+        "redemption": redemption,
+        "source": key,              # breakdown 用
+    }
+    return record_mode, current_units, gain, unit, key, detail
 
 
 def calc_sp_for_event(mode: str) -> tuple[int, dict]:
@@ -141,12 +203,13 @@ def add_sp_by_mode(
     redemption: bool,
     db: Session
 ) -> int:
-    today = date.today()
+    today = today_local()
 
     if mode in ("walking", "running"):
-        current_units, gain, unit, key, detail = get_unit_info(mode, redemption, step_count, distance_km)
+        record_mode, current_units, gain, unit, key, detail = get_unit_info(
+            mode, redemption, step_count, distance_km
+        )
         new_sp = current_units * gain
-
         if new_sp <= 0:
             return 0
 
@@ -156,15 +219,17 @@ def add_sp_by_mode(
             return 0
 
         max_addable_sp = min(new_sp, remaining)
-        record = get_sp_record_by_date(user_id, mode, today, db)
+        # ← “保存モード”で1日1レコードに分ける
+        record = get_sp_record_by_date(user_id, week_id, record_mode, today, db)
 
         if record:
             prev_value = record.detail.get(key, 0)
-            prev_units = int(prev_value // unit)
-            new_units = int(detail[key] // unit)
+            prev_unit  = record.detail.get("unit", unit)  # 互換性のため
+            prev_units = int(prev_value // prev_unit)
+            new_units  = int(detail[key] // unit)
 
             unit_diff = new_units - prev_units
-            delta_sp = unit_diff * gain
+            delta_sp  = unit_diff * gain
 
             if unit_diff <= 0 or delta_sp <= 0:
                 return 0
@@ -173,17 +238,15 @@ def add_sp_by_mode(
             update_sp_record(record, record.sp + delta_sp, detail, db)
             return delta_sp
         else:
-            add_sp_record(user_id, week_id, today, max_addable_sp, mode, detail, db)
+            add_sp_record(user_id, week_id, today, max_addable_sp, record_mode, detail, db)
             return max_addable_sp
 
     elif mode in ("wake", "photo"):
-        # 1日1回制限: すでに今日の記録があれば無効
-        existing = get_sp_record_by_date(user_id, mode, today, db)
+        existing = get_sp_record_by_date(user_id, week_id, mode, today, db)
         if existing:
             return 0
 
         new_sp, detail = calc_sp_for_event(mode)
-
         today_total = get_today_sp(user_id, week_id, db)
         remaining = SP_DAY_CAP - today_total
         if remaining <= 0:
@@ -195,12 +258,10 @@ def add_sp_by_mode(
 
     elif mode == "mvp":
         new_sp, detail = calc_sp_for_event(mode)
-
         today_total = get_today_sp(user_id, week_id, db)
         remaining = SP_DAY_CAP - today_total
         if remaining <= 0:
             return 0
-
         max_addable_sp = min(new_sp, remaining)
         add_sp_record(user_id, week_id, today, max_addable_sp, mode, detail, db)
         return max_addable_sp

--- a/backend/features/points/point_service.py
+++ b/backend/features/points/point_service.py
@@ -24,7 +24,6 @@ def add_bp_from_cumulative(
     user_id: int,
     steps_total: int,
     distance_total_km: float,
-    device_id: str | None = None,
     sent_date: date | None = None,
 ) -> int:
     """
@@ -39,13 +38,11 @@ def add_bp_from_cumulative(
     new_walk_units = steps_total // BP_WALK_UNIT
     new_run_units = int(distance_total_km // BP_RUN_UNIT)
 
-    cur = get_cursor(db, user_id, on_date, device_id)
+    cur = get_cursor(db, user_id, on_date)
     if cur is None:
-        # 初回：累積ぶんを丸ごと“単位換算”で付与
         delta_walk_units = new_walk_units
         delta_run_units  = new_run_units
     else:
-        # 通常：単位差分のみ
         delta_walk_units = max(new_walk_units - cur.last_walk_units, 0)
         delta_run_units  = max(new_run_units  - cur.last_run_units, 0)
 
@@ -58,7 +55,6 @@ def add_bp_from_cumulative(
         db=db,
         user_id=user_id,
         on_date=on_date,
-        device_id=device_id,
         last_walk_units=new_walk_units,
         last_run_units=new_run_units,
         last_steps_total=steps_total,

--- a/backend/features/points/sp_crud.py
+++ b/backend/features/points/sp_crud.py
@@ -4,6 +4,7 @@ from sqlalchemy import func, select
 from datetime import date
 from collections import OrderedDict
 from backend.features.points.point_constants import *
+from backend.features.weeks.week_service import today_local
 
 # SPレコードの追加。 detailは辞書型で受け取り、内部でJSON文字列化
 def add_sp_record(user_id: int, week_id: int, record_date: date, sp_value: int, mode: str, detail: dict, db: Session) -> None:
@@ -24,11 +25,12 @@ def update_sp_record(record: SPRecord, new_sp: int, detail: dict, db: Session) -
     record.detail = detail
     db.commit()
 
-# SPレコードの取得
-def get_sp_record_by_date(user_id: int, mode: str, target_date: date, db: Session) -> SPRecord | None:
+# SPレコードの取得（週も含めて一意に）
+def get_sp_record_by_date(user_id: int, week_id: int, mode: str, target_date: date, db: Session) -> SPRecord | None:
     result = db.execute(
         select(SPRecord).where(
             SPRecord.user_id == user_id,
+            SPRecord.week_id == week_id,
             SPRecord.date == target_date,
             SPRecord.mode == mode
         )
@@ -37,7 +39,7 @@ def get_sp_record_by_date(user_id: int, mode: str, target_date: date, db: Sessio
     
 # 指定ユーザーの本日文のSP獲得合計を返す。
 def get_today_sp(user_id: int, week_id: int, db: Session) -> int:
-    today = date.today()
+    today = today_local()
     total = db.query(func.sum(SPRecord.sp)).filter(
         SPRecord.user_id == user_id,
         SPRecord.week_id == week_id,

--- a/backend/features/points/sp_router.py
+++ b/backend/features/points/sp_router.py
@@ -7,6 +7,7 @@ from backend.features.auth.auth_dependencies import get_current_user
 from backend.utils.utils import validate_user
 from backend.features.points.sp_schemas import *
 from backend.features.points.point_service import *
+from backend.features.points.sp_crud import get_today_sp, get_weeks_sp_total, get_sp_breakdown_by_date
 from backend.features.weeks.week_service import today_local
 
 router = APIRouter()

--- a/backend/features/points/sp_router.py
+++ b/backend/features/points/sp_router.py
@@ -13,7 +13,7 @@ from backend.features.weeks.week_service import today_local
 router = APIRouter()
 
 # SP加算（差分）
-@router.post("/add", response_model=SPBalanceResponse, responses={
+@router.post("/add", response_model=SPChangeResponse, responses={
     200: {"description": "SP加算成功"},
     401: {"description": "認証されていません"},
     403: {"description": "不正なSP操作です"},
@@ -25,7 +25,9 @@ def add_sp(
     db: Session = Depends(get_db)
 ):
     validate_user(request.user_id, current_user.id)
-    current_sp = add_sp_from_activity(
+
+    # 今回加算された「差分」だけが返る（delta）
+    delta = add_sp_from_activity(
         db=db,
         user_id=request.user_id,
         week_id=request.week_id,
@@ -34,7 +36,18 @@ def add_sp(
         mode=request.mode.value,
         redemption=request.redemption
     )
-    return SPBalanceResponse(user_id=request.user_id, current_sp=current_sp)
+
+    # 最新の本日合計・週合計を取得して返す
+    today_total = get_today_sp(user_id=request.user_id, week_id=request.week_id, db=db)
+    week_total  = get_weeks_sp_total(user_id=request.user_id, week_id=request.week_id, db=db)
+
+    return SPChangeResponse(
+        user_id=request.user_id,
+        delta_sp=delta,
+        today_total_sp=today_total,
+        week_total_sp=week_total
+    )
+
 
 
 # 今日のSP取得量
@@ -92,7 +105,7 @@ def get_sp_breakdown_api(
 
 
 # イベント系SP加算（MVP・Wake・Photo）
-@router.post("/event", response_model=SPBalanceResponse, responses={
+@router.post("/event", response_model=SPChangeResponse, responses={
     200: {"description": "イベントSP加算成功"},
     403: {"description": "不正なSP操作です"},
     500: {"description": "サーバーエラー"}
@@ -103,7 +116,9 @@ def add_event_sp_api(
     db: Session = Depends(get_db)
 ):
     validate_user(request.user_id, current_user.id)
-    sp = add_sp_by_mode(
+
+    # ここも「今回加算分（delta）」が返る
+    delta = add_sp_by_mode(
         user_id=request.user_id,
         week_id=request.week_id,
         mode=request.mode,
@@ -112,4 +127,13 @@ def add_event_sp_api(
         redemption=False,
         db=db
     )
-    return SPBalanceResponse(user_id=request.user_id, current_sp=sp)
+
+    today_total = get_today_sp(user_id=request.user_id, week_id=request.week_id, db=db)
+    week_total  = get_weeks_sp_total(user_id=request.user_id, week_id=request.week_id, db=db)
+
+    return SPChangeResponse(
+        user_id=request.user_id,
+        delta_sp=delta,
+        today_total_sp=today_total,
+        week_total_sp=week_total
+    )

--- a/backend/features/points/sp_router.py
+++ b/backend/features/points/sp_router.py
@@ -7,6 +7,7 @@ from backend.features.auth.auth_dependencies import get_current_user
 from backend.utils.utils import validate_user
 from backend.features.points.sp_schemas import *
 from backend.features.points.point_service import *
+from backend.features.weeks.week_service import today_local
 
 router = APIRouter()
 
@@ -84,7 +85,7 @@ def get_sp_breakdown_api(
 ):
     validate_user(user_id, current_user.id)
     if target_date is None:
-        target_date = date.today()
+        target_date = today_local()
     breakdown = get_sp_breakdown_by_date(user_id, week_id, target_date, db)
     return SPBreakdownResponse(user_id=user_id, breakdown=breakdown)
 

--- a/backend/features/points/sp_schemas.py
+++ b/backend/features/points/sp_schemas.py
@@ -1,6 +1,6 @@
 
 from typing import Dict
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from enum import Enum
 from datetime import date
 
@@ -22,6 +22,12 @@ class SPAddRequest(BaseModel):
 class SPBalanceResponse(BaseModel):
     user_id: int
     current_sp: int
+
+class SPChangeResponse(BaseModel):
+    user_id: int
+    delta_sp: int = Field(..., description="今回加算されたSP")
+    today_total_sp: int = Field(..., description="今日の合計SP")
+    week_total_sp: int = Field(..., description="週合計SP")
 
 class SPEventRequest(BaseModel):
     user_id: int


### PR DESCRIPTION
累積加算の処理を追加するのにあたってポイント周りのリファクタリングや修正を行なった。

累積加算処理のmodel, service, crud, routerの追加
sp,bpの加算処理のレスポンスの形を統一するのにあたって、model,schemaの修正
日付の取得方法をtoday_lacal()に統一
